### PR TITLE
Fix invalid lines in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,9 +3,7 @@ version=1.0.0
 author=M Hotchin <github@hotchin.net>
 maintainer=M Hotchin <github@hotchin.net>
 sentence=Use Arduino to control your BalBoa Spa Pack.
-paragraph=Monitor and control your WiFi connected BalBoa spa.  This requires that your spa
-pack have the Balboa Wi-Fi module 50350 installed.  If you can use the  Balboa Worldwide App (bwa™) to control your spa, this should work as well.
-Tested on Arduino Uno, Arduino Mega 2560, Wemos D1 R1 (ESP8266) and Wemos D1 R32 (ESP32) boards.
+paragraph=Monitor and control your WiFi connected BalBoa spa.  This requires that your spa pack have the Balboa Wi-Fi module 50350 installed.  If you can use the  Balboa Worldwide App (bwaâ„¢) to control your spa, this should work as well. Tested on Arduino Uno, Arduino Mega 2560, Wemos D1 R1 (ESP8266) and Wemos D1 R32 (ESP32) boards.
 category=Communications
 url=https://github.com/MHotchin/BalBoaSpa
 architectures=*


### PR DESCRIPTION
Each line in library.properties must either contain an '=', start with a #, or be whitespace. Installation of a library with an invalid line will cause compilation of any code (even if it doesn't `#include` the library) to fail:
```
Error reading file (E:\arduino\libraries\BalBoaSpa\library.properties:6): Invalid line format, should be 'key=value'
```
Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format